### PR TITLE
Fix a bug

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -75,7 +75,11 @@ if (chromeContentSettings) {
     for (var index in callback) {
       if (callback.hasOwnProperty(index)) {
         //console.log(callback[index]);
-        cache[index] = JSON.parse(callback[index].newValue);
+        if (index === 'version') {
+            cache[index] = callback[index].newValue;
+        } else {
+            cache[index] = JSON.parse(callback[index].newValue);
+        }
         //console.log(cache);
       }
     }


### PR DESCRIPTION
When storing the version field, the value is actually a string and should not be passed to JSON.parse. This shows a error in chrome devtools when installing the extension.